### PR TITLE
Add Software Gardening Almanack workflow check for repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# nextflow ignores
+.nextflow
+work
+.nextflow.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
-# Use the official Ubuntu image as the base
-FROM ubuntu:latest
+# use python image based on debian
+FROM python:3.11-bullseye
 
-# Install dependencies
-RUN apt-get update && apt-get install -y git python3 python3-pip curl openjdk-11-jre
+# Install apt dependencies
+RUN apt-get update && \
+    apt-get install -y \
+    git \
+    curl \
+    openjdk-11-jre
 
 # Install Nextflow
 RUN curl -s https://get.nextflow.io | bash && mv nextflow /usr/local/bin/
 
 # Install Software Gardening Almanack
-RUN pip install --upgrade pip && \
-    pip install almanack
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir almanack
 
 # Set working directory
 WORKDIR /workspace
@@ -20,8 +24,9 @@ COPY first-pass.nf /workspace/first-pass.nf
 # Add execute permissions to the Nextflow script
 RUN chmod +x /workspace/first-pass.nf
 
-# Set entrypoint for Nextflow
-ENTRYPOINT ["nextflow", "run", "/workspace/first-pass.nf"]
+# Set entrypoint for Nextflow, allowing for an HTTP link to be passed in
+# i.e. docker run cckp-toolkit https://some-git-url
+ENTRYPOINT ["bash", "-c", "nextflow run /workspace/first-pass.nf --repo_url $0"]
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
 WORKDIR /workspace
 
 # Copy Nextflow script into the working directory
-COPY first-pass.nf /workspace/first-pass.nf
+COPY first-pass.nf nextflow.config /workspace/
 
 # Add execute permissions to the Nextflow script
 RUN chmod +x /workspace/first-pass.nf

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ RUN apt-get update && apt-get install -y git python3 python3-pip curl openjdk-11
 # Install Nextflow
 RUN curl -s https://get.nextflow.io | bash && mv nextflow /usr/local/bin/
 
+# Install Software Gardening Almanack
+RUN pip install --upgrade pip && \
+    pip install almanack
+
 # Set working directory
 WORKDIR /workspace
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This Nextflow workflow `first-pass.nf` performs a high level quality check on to
 
 4. **CheckTests**: This process looks for test directories or files within the repository.
 
+5. **CheckAlmanack**: This process implements the [Software Gardening Almanack](https://github.com/software-gardening/almanack) to gather various metrics about the repository.
+
 ## Setup
 
 Install Nextflow:
@@ -37,6 +39,21 @@ Replace <repository-url> with the URL of the Git repository you wish to check.
 ```bash
 nextflow run first-pass.nf --repo_url https://github.com/example/repo.git
 ```
+
+## Docker Usage
+
+You may also use Docker to run the CCKP Toolkit Workflow as an alternative to the above.
+First, [install Docker](https://docs.docker.com/engine/install/) on your system.
+Then, use the commands below as an example of how to run the workflow.
+
+```bash
+# build an image for cckp toolkit workflow
+docker build -t cckp-toolkit-workflow .
+
+# run the image for cckp toolkit workflow, passing in a git repo url
+docker run cckp-toolkit-workflow https://github.com/mc2-center/cckp-toolkit-workflow
+```
+
 ### Tools You Can Test With:
 
 1. **Python Optimal Transport Library**  

--- a/first-pass.nf
+++ b/first-pass.nf
@@ -111,6 +111,22 @@ process CheckTests {
     """
 }
 
+process CheckAlmanack {
+    input:
+    path repo
+
+    output:
+    path "${params.output_dir}/example.json", emit: almanack_results
+
+    script:
+    """
+    mkdir -p ${params.output_dir}  # Create the output directory if it doesn't exist
+    python -c "import json; import almanack; print(json.dumps(almanack.table(repo_path='${repo}'), indent=4))" > \
+         ${params.output_dir}/example.json
+    """
+}
+
+
 
 workflow {
     repo_url = params.repo_url
@@ -119,5 +135,6 @@ workflow {
     CheckReadme(repoPath)
     CheckDependencies(repoPath)
     CheckTests(repoPath)
+    CheckAlmanack(repoPath)
 
 }

--- a/first-pass.nf
+++ b/first-pass.nf
@@ -116,7 +116,7 @@ process CheckAlmanack {
     path repo
 
     output:
-    path "${params.output_dir}/example.json", emit: almanack_results
+    path "${params.output_dir}/almanack-results.json", emit: almanack_results
 
     script:
     """

--- a/first-pass.nf
+++ b/first-pass.nf
@@ -122,7 +122,7 @@ process CheckAlmanack {
     """
     mkdir -p ${params.output_dir}  # Create the output directory if it doesn't exist
     python -c "import json; import almanack; print(json.dumps(almanack.table(repo_path='${repo}'), indent=4))" > \
-         ${params.output_dir}/example.json
+         ${params.output_dir}/almanack-results.json
     """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,6 @@
 params {
     repo_url = '<repository-url>'
+    output_dir = 'results'
 }
 
 process {
@@ -15,5 +16,4 @@ process {
     }
 }
 
-workDir = '/Users/agopalan/cckp-toolkit-workflow'
-
+workDir = 'work'


### PR DESCRIPTION
In reading through the existing work I felt inspired to help in the efforts by adding a related project which can help perform measurements on repositories. This PR adds a [Software Gardening Almanack](https://github.com/software-gardening/almanack) check to the CCKP Toolkit Workflow. `CheckAlmanack` gathers a table of measurements on the given workflow repository and exports the results as formatted JSON in an `output_dir`. I tried to keep all additions in alignment with existing checks (apologies in advance for any false assumptions!).

The work here is a completely optional proposal of how the Almanack package could be used to perform measurements as part of this project - please feel free to close without merging or provide feedback if there are parts which should be modified before accepting any changes. Thank you so much for taking a look and any input you might have!

Notes for clarity:

- I made changes to the `nextflow.config` to help generalize the use on multiple systems.
- I made changes to the `Dockerfile` to help install a specific version of Python from the base image (avoiding customized installation on Ubuntu, which can involve many more lines) and to use `docker run ...` to implement the workflow with parameters.