### PR TITLE
Fix `nf-test` installation for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,8 @@ jobs:
       
       - name: Install nf-test
         run: |
-          curl -fsSL https://get.nf-test.com | bash
-          mv nf-test /usr/local/bin/
-          nf-test version
+          wget -qO- https://get.nf-test.com | bash
+          sudo mv nf-test /usr/local/bin/
       
       - name: Set up Docker
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
# Pull Request

## Description

After submitting #57 I noticed that the tests were failing, seemingly due to `nf-test` installation references. In looking at the documentation for installation I noticed that the [action step to install ](https://www.nf-test.com/tutorials/github-actions/?h=github+actions)has changed from what's present here. This PR adds the change from `nf-test` recommendation in an attempt to see tests pass.

## Changes Made
- [x] Updated GitHub Actions step for installing `nf-test`

## Related Issues
References #57 

## Checklist
- [x] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] All tests pass locally.

## Additional Notes
Any additional information or context that might be helpful for reviewers. 